### PR TITLE
feat: add reorder_items AI tool

### DIFF
--- a/src/lib/server/ai.ts
+++ b/src/lib/server/ai.ts
@@ -101,7 +101,7 @@ export function shoppingTools(storeId: string | null) {
 
 		reorder_items: tool({
 			description:
-				'Reorder the unchecked items on the shopping list, e.g. to group related items together. Call list_items first, then pass every unchecked item id in the new order — the array must contain exactly the current unchecked items, just rearranged.',
+				'Reorder the unchecked items on the shopping list, e.g. to group related items together. The array must contain exactly the current unchecked item ids, just rearranged.',
 			inputSchema: z.object({
 				orderedIds: z.array(z.string()).describe('Ids of all unchecked items, in the desired order')
 			}),

--- a/src/lib/server/ai.ts
+++ b/src/lib/server/ai.ts
@@ -119,12 +119,12 @@ export function systemPrompt(storeName: string): string {
 		`The user's active list is: ${storeName}. Every tool you call is already scoped to it.`,
 		'Help users manage their shopping list using natural language.',
 		'Rules:',
-		'- Always call list_items before update_item, set_item_checked or remove_item to get accurate ids.',
+		'- Always call list_items before update_item, set_item_checked, remove_item or reorder_items to get accurate ids.',
 		'- Checking an item off keeps it on the list; removing deletes it. Do not confuse the two.',
 		'- For ambiguous requests, ask one concise clarifying question.',
 		'- You can execute multiple operations for a single user message.',
 		'- When operating on many items, use remove_items or clear_checked and batch tool calls in a single turn rather than one at a time.',
-		'- To reorder the list, call reorder_items with every unchecked item id in the new order.',
+		'- To reorder the list, call list_items right before reorder_items and pass every unchecked item id in the new order — the set must match exactly, especially if items were just added or removed in the same turn.',
 		'- Keep responses brief — just confirm what you did or ask what you need.',
 		'- Reply in plain sentences. Do not use markdown formatting.'
 	].join('\n');

--- a/src/lib/server/ai.ts
+++ b/src/lib/server/ai.ts
@@ -97,6 +97,18 @@ export function shoppingTools(storeId: string | null) {
 				await shopping.clearChecked(storeId);
 				return { cleared: true };
 			}
+		}),
+
+		reorder_items: tool({
+			description:
+				'Reorder the unchecked items on the shopping list, e.g. to group related items together. Call list_items first, then pass every unchecked item id in the new order — the array must contain exactly the current unchecked items, just rearranged.',
+			inputSchema: z.object({
+				orderedIds: z.array(z.string()).describe('Ids of all unchecked items, in the desired order')
+			}),
+			execute: async ({ orderedIds }) => {
+				await shopping.reorderItems(orderedIds, storeId);
+				return { reordered: orderedIds.length };
+			}
 		})
 	};
 }
@@ -112,6 +124,7 @@ export function systemPrompt(storeName: string): string {
 		'- For ambiguous requests, ask one concise clarifying question.',
 		'- You can execute multiple operations for a single user message.',
 		'- When operating on many items, use remove_items or clear_checked and batch tool calls in a single turn rather than one at a time.',
+		'- To reorder the list, call reorder_items with every unchecked item id in the new order.',
 		'- Keep responses brief — just confirm what you did or ask what you need.',
 		'- Reply in plain sentences. Do not use markdown formatting.'
 	].join('\n');


### PR DESCRIPTION
## Summary
- Adds a `reorder_items` tool to `shoppingTools(storeId)` in `src/lib/server/ai.ts`, wired to the existing `shopping.reorderItems(orderedIds, storeId)` service function (already used by the UI's drag-reorder).
- Updates the assistant's system prompt to instruct it to call `reorder_items` with every unchecked item id in the new order.

Closes #36

## Test plan
- [x] `pnpm run check`
- [x] `pnpm run lint`
- [ ] Manual verification in the running app (not done here per instruction to avoid dev server/docker)