### PR TITLE
feat: allow AI to correct item letter case when certain

### DIFF
--- a/src/lib/server/ai.ts
+++ b/src/lib/server/ai.ts
@@ -110,7 +110,7 @@ export function systemPrompt(storeName: string): string {
 		'Help users manage their shopping list using natural language.',
 		'Rules:',
 		'- Always call list_items before update_item, set_item_checked, remove_items or reorder_items to get accurate ids.',
-		'- You may correct letter case in add_item or update_item calls (e.g. "milk" -> "Milk"), but only when fully certain of the correct canonical name and casing; otherwise keep the original casing exactly as given.',
+		'- You may correct letter case in add_item or update_item calls (e.g. "milk" -> "Milk") when fully certain of the correct capitalization. Do not change spelling, wording, or otherwise rename the item — if not fully certain, keep the original casing exactly as given.',
 		'- Checking an item off keeps it on the list; removing deletes it. Do not confuse the two.',
 		'- For ambiguous requests, ask one concise clarifying question.',
 		'- You can execute multiple operations for a single user message.',

--- a/src/lib/server/ai.ts
+++ b/src/lib/server/ai.ts
@@ -110,6 +110,7 @@ export function systemPrompt(storeName: string): string {
 		'Help users manage their shopping list using natural language.',
 		'Rules:',
 		'- Always call list_items before update_item, set_item_checked, remove_items or reorder_items to get accurate ids.',
+		'- You may correct letter case in add_item or update_item calls (e.g. "milk" -> "Milk"), but only when fully certain of the correct canonical name and casing; otherwise keep the original casing exactly as given.',
 		'- Checking an item off keeps it on the list; removing deletes it. Do not confuse the two.',
 		'- For ambiguous requests, ask one concise clarifying question.',
 		'- You can execute multiple operations for a single user message.',


### PR DESCRIPTION
## Summary
- Adds one rule to the shopping-list assistant's system prompt (`src/lib/server/ai.ts`) permitting `add_item`/`update_item` to correct an item's letter case, but only when the AI is fully certain of the canonical name/casing — otherwise it preserves the user's original casing exactly.

Closes #42

## Test plan
- [x] `pnpm run check` — 0 errors
- [x] `pnpm run lint` — passes
- [ ] No automated test added: this is a model-behavior/prompt instruction, not deterministic logic, so it isn't covered by the repo's existing (nonexistent) test setup. Recommend manually verifying in `pnpm run dev` with a couple of casing examples (e.g. "add milk", an ambiguous brand name).