### PR TITLE
ci: run CD on every successful CI build of main

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,6 +1,8 @@
 name: CD
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,17 +1,25 @@
 name: CD
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
     branches: [main]
+    types: [completed]
   workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+
+    env:
+      SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SHA }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -29,6 +37,6 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/tshopper:latest
-            ${{ secrets.DOCKER_USERNAME }}/tshopper:${{ github.sha }}
+            ${{ secrets.DOCKER_USERNAME }}/tshopper:${{ env.SHA }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Closes #44

The CD workflow was `workflow_dispatch`-only. It now runs automatically for every merge/push to `main`, gated on CI.

- Triggered by CI's `workflow_run` completion on `main` rather than the push itself, so a failed typecheck, lint or build cannot publish an image (`if: conclusion == 'success'`).
- Checks out and tags `workflow_run.head_sha` — the exact commit CI validated — so back-to-back merges can't build the wrong tree.
- Manual `workflow_dispatch` still works and bypasses the gate.

Note: CD only ever runs from the copy of `CD.yml` on `main`, so this change first takes effect after merge.